### PR TITLE
Migrate to Curve25519 vs Keychain's RSA

### DIFF
--- a/ios/Curve25519.swift
+++ b/ios/Curve25519.swift
@@ -1,0 +1,24 @@
+import CryptoKit
+import Foundation
+
+@available(iOS 13, *)
+@objc final class Curve25519: NSObject {
+    @objc class func generateKeypair() -> Keypair {
+        .init(privateKey: .init())
+    }
+
+    @objc class func signature(forPayload data: Data, privateKey: Data) throws -> Data {
+        try CryptoKit.Curve25519.Signing.PrivateKey(rawRepresentation: privateKey)
+            .signature(for: data)
+    }
+
+    @objc final class Keypair: NSObject {
+        @objc let publicKey: Data
+        @objc let privateKey: Data
+
+        init(privateKey: CryptoKit.Curve25519.Signing.PrivateKey) {
+            self.publicKey = privateKey.publicKey.rawRepresentation
+            self.privateKey = privateKey.rawRepresentation
+        }
+    }
+}

--- a/ios/ReactNativeBiometrics-Bridging-Header.h
+++ b/ios/ReactNativeBiometrics-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -123,12 +123,15 @@ RCT_EXPORT_METHOD(createSignature: (NSDictionary *)params resolver:(RCTPromiseRe
     NSString *promptMessage = [RCTConvert NSString:params[@"promptMessage"]];
     NSString *payload = [RCTConvert NSString:params[@"payload"]];
 
+    LAContext *context = [[LAContext alloc] init];
+    context.localizedReason = promptMessage;
+
     NSData *biometricKeyService = [self getBiometricKeyService];
     NSDictionary *query = @{
-                            (id)kSecUseOperationPrompt: promptMessage
                             (id)kSecClass: (id)kSecClassGenericPassword,
                             (id)kSecAttrService: biometricKeyService,
                             (id)kSecReturnData: @YES,
+                            (id)kSecUseAuthenticationContext: context,
                             };
     NSData *privateKey;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFDataRef *)&privateKey);
@@ -222,10 +225,12 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
 
 - (BOOL) doesBiometricKeyExist {
   NSString *biometricKeyService = [self getBiometricKeyService];
+  LAContext *context = [[LAContext alloc] init];
+  context.interactionNotAllowed = @(YES);
   NSDictionary *searchQuery = @{
-                                (id)kSecUseAuthenticationUI: (id)kSecUseAuthenticationUIFail
                                 (id)kSecClass: (id)kSecClassGenericPassword,
                                 (id)kSecAttrService: biometricKeyService,
+                                (id)kSecUseAuthenticationContext: context
                                 };
 
   OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchQuery, nil);

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(createKeys: (NSDictionary *)params resolver:(RCTPromiseResolve
     CFErrorRef error = NULL;
     BOOL allowDeviceCredentials = [RCTConvert BOOL:params[@"allowDeviceCredentials"]];
 
-    SecAccessControlCreateFlags secCreateFlag = kSecAccessControlBiometryAny;
+    SecAccessControlCreateFlags secCreateFlag = kSecAccessControlBiometryCurrentSet;
 
     if (allowDeviceCredentials == TRUE) {
       secCreateFlag = kSecAccessControlUserPresence;

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -64,36 +64,30 @@ RCT_EXPORT_METHOD(createKeys: (NSDictionary *)params resolver:(RCTPromiseResolve
       return;
     }
 
-    NSData *biometricKeyTag = [self getBiometricKeyTag];
+    Keys* keys = [Curve25519 generateKeypair];
+
+    NSData *biometricKeyService = [self getBiometricKeyService];
     NSDictionary *keyAttributes = @{
-                                    (id)kSecClass: (id)kSecClassKey,
-                                    (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
-                                    (id)kSecAttrKeySizeInBits: @2048,
-                                    (id)kSecPrivateKeyAttrs: @{
-                                        (id)kSecAttrIsPermanent: @YES,
-                                        (id)kSecUseAuthenticationUI: (id)kSecUseAuthenticationUIAllow,
-                                        (id)kSecAttrApplicationTag: biometricKeyTag,
-                                        (id)kSecAttrAccessControl: (__bridge_transfer id)sacObject
-                                        }
+                                    (id)kSecClass: (id)kSecClassGenericPassword,
+                                    (id)kSecAttrService: biometricKeyService,
+                                    (id)kSecAttrAccessControl: (__bridge_transfer id)sacObject,
+                                    (id)kSecValueData: (id)keys.privateKey
                                     };
 
     [self deleteBiometricKey];
-    NSError *gen_error = nil;
-    id privateKey = CFBridgingRelease(SecKeyCreateRandomKey((__bridge CFDictionaryRef)keyAttributes, (void *)&gen_error));
 
-    if(privateKey != nil) {
-      id publicKey = CFBridgingRelease(SecKeyCopyPublicKey((SecKeyRef)privateKey));
-      CFDataRef publicKeyDataRef = SecKeyCopyExternalRepresentation((SecKeyRef)publicKey, nil);
-      NSData *publicKeyData = (__bridge NSData *)publicKeyDataRef;
-      NSData *publicKeyDataWithHeader = [self addHeaderPublickey:publicKeyData];
-      NSString *publicKeyString = [publicKeyDataWithHeader base64EncodedStringWithOptions:0];
+    NSError *storage_error = nil;
+    OSStatus status = SecItemAdd((__bridge CFDictionaryRef)keyAttributes, (void *)&storage_error);
+
+    if(keys.publicKey != nil) {
+      NSString *publicKeyString = [keys.publicKey base64EncodedStringWithOptions:0];
 
       NSDictionary *result = @{
         @"publicKey": publicKeyString,
       };
       resolve(result);
     } else {
-      NSString *message = [NSString stringWithFormat:@"Key generation error: %@", gen_error];
+      NSString *message = [NSString stringWithFormat:@"Key storage error: %@", storage_error];
       reject(@"storage_error", message, nil);
     }
   });
@@ -129,21 +123,20 @@ RCT_EXPORT_METHOD(createSignature: (NSDictionary *)params resolver:(RCTPromiseRe
     NSString *promptMessage = [RCTConvert NSString:params[@"promptMessage"]];
     NSString *payload = [RCTConvert NSString:params[@"payload"]];
 
-    NSData *biometricKeyTag = [self getBiometricKeyTag];
+    NSData *biometricKeyService = [self getBiometricKeyService];
     NSDictionary *query = @{
-                            (id)kSecClass: (id)kSecClassKey,
-                            (id)kSecAttrApplicationTag: biometricKeyTag,
-                            (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
-                            (id)kSecReturnRef: @YES,
                             (id)kSecUseOperationPrompt: promptMessage
+                            (id)kSecClass: (id)kSecClassGenericPassword,
+                            (id)kSecAttrService: biometricKeyService,
+                            (id)kSecReturnData: @YES,
                             };
-    SecKeyRef privateKey;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&privateKey);
+    NSData *privateKey;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFDataRef *)&privateKey);
 
     if (status == errSecSuccess) {
       NSError *error;
       NSData *dataToSign = [payload dataUsingEncoding:NSUTF8StringEncoding];
-      NSData *signature = CFBridgingRelease(SecKeyCreateSignature(privateKey, kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256, (CFDataRef)dataToSign, (void *)&error));
+      NSData *signature = [Curve25519 signatureForPayload:dataToSign privateKey:privateKey error:&error];
 
       if (signature != nil) {
         NSString *signatureString = [signature base64EncodedStringWithOptions:0];
@@ -223,19 +216,16 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
   });
 }
 
-- (NSData *) getBiometricKeyTag {
-  NSString *biometricKeyAlias = @"com.rnbiometrics.biometricKey";
-  NSData *biometricKeyTag = [biometricKeyAlias dataUsingEncoding:NSUTF8StringEncoding];
-  return biometricKeyTag;
+- (NSString *) getBiometricKeyService {
+  return @"com.rnbiometrics.biometricKey";
 }
 
 - (BOOL) doesBiometricKeyExist {
-  NSData *biometricKeyTag = [self getBiometricKeyTag];
+  NSString *biometricKeyService = [self getBiometricKeyService];
   NSDictionary *searchQuery = @{
-                                (id)kSecClass: (id)kSecClassKey,
-                                (id)kSecAttrApplicationTag: biometricKeyTag,
-                                (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
                                 (id)kSecUseAuthenticationUI: (id)kSecUseAuthenticationUIFail
+                                (id)kSecClass: (id)kSecClassGenericPassword,
+                                (id)kSecAttrService: biometricKeyService,
                                 };
 
   OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchQuery, nil);
@@ -243,11 +233,10 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
 }
 
 -(OSStatus) deleteBiometricKey {
-  NSData *biometricKeyTag = [self getBiometricKeyTag];
+  NSString *biometricKeyService = [self getBiometricKeyService];
   NSDictionary *deleteQuery = @{
-                                (id)kSecClass: (id)kSecClassKey,
-                                (id)kSecAttrApplicationTag: biometricKeyTag,
-                                (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA
+                                (id)kSecClass: (id)kSecClassGenericPassword,
+                                (id)kSecAttrService: biometricKeyService,
                                 };
 
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef)deleteQuery);
@@ -288,68 +277,6 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
   }
 
   return message;
-}
-
-
-- (NSData *)addHeaderPublickey:(NSData *)publicKeyData {
-
-    unsigned char builder[15];
-    NSMutableData * encKey = [[NSMutableData alloc] init];
-    unsigned long bitstringEncLength;
-
-    static const unsigned char _encodedRSAEncryptionOID[15] = {
-
-        /* Sequence of length 0xd made up of OID followed by NULL */
-        0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
-        0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00
-
-    };
-    // When we get to the bitstring - how will we encode it?
-    if  ([publicKeyData length ] + 1  < 128 )
-        bitstringEncLength = 1 ;
-    else
-        bitstringEncLength = (([publicKeyData length ] +1 ) / 256 ) + 2 ;
-    //
-    //        // Overall we have a sequence of a certain length
-    builder[0] = 0x30;    // ASN.1 encoding representing a SEQUENCE
-    //        // Build up overall size made up of -
-    //        // size of OID + size of bitstring encoding + size of actual key
-    size_t i = sizeof(_encodedRSAEncryptionOID) + 2 + bitstringEncLength + [publicKeyData length];
-    size_t j = encodeLength(&builder[1], i);
-    [encKey appendBytes:builder length:j +1];
-
-    // First part of the sequence is the OID
-    [encKey appendBytes:_encodedRSAEncryptionOID
-                 length:sizeof(_encodedRSAEncryptionOID)];
-
-    // Now add the bitstring
-    builder[0] = 0x03;
-    j = encodeLength(&builder[1], [publicKeyData length] + 1);
-    builder[j+1] = 0x00;
-    [encKey appendBytes:builder length:j + 2];
-
-    // Now the actual key
-    [encKey appendData:publicKeyData];
-
-    return encKey;
-}
-
-size_t encodeLength(unsigned char * buf, size_t length) {
-
-    // encode length in ASN.1 DER format
-    if (length < 128) {
-        buf[0] = length;
-        return 1;
-    }
-
-    size_t i = (length / 256) + 1;
-    buf[0] = i + 0x80;
-    for (size_t j = 0 ; j < i; ++j) {
-        buf[i - j] = length & 0xFF;
-        length = length >> 8;
-    }
-
-    return i + 1;
 }
 
 @end

--- a/ios/ReactNativeBiometrics.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBiometrics.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22E2E05628DEBDAD00327719 /* Curve25519.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E2E05528DEBDAD00327719 /* Curve25519.swift */; };
 		B3E7B58A1CC2AC0600A0062D /* ReactNativeBiometrics.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* ReactNativeBiometrics.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libReactNativeBiometrics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeBiometrics.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		22E2E05428DEBDAD00327719 /* ReactNativeBiometrics-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReactNativeBiometrics-Bridging-Header.h"; sourceTree = "<group>"; };
+		22E2E05528DEBDAD00327719 /* Curve25519.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Curve25519.swift; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* ReactNativeBiometrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactNativeBiometrics.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* ReactNativeBiometrics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactNativeBiometrics.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,7 +55,9 @@
 			children = (
 				B3E7B5881CC2AC0600A0062D /* ReactNativeBiometrics.h */,
 				B3E7B5891CC2AC0600A0062D /* ReactNativeBiometrics.m */,
+				22E2E05528DEBDAD00327719 /* Curve25519.swift */,
 				134814211AA4EA7D00B7C361 /* Products */,
+				22E2E05428DEBDAD00327719 /* ReactNativeBiometrics-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -87,6 +92,7 @@
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 1400;
 					};
 				};
 			};
@@ -95,6 +101,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -112,6 +119,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22E2E05628DEBDAD00327719 /* Curve25519.swift in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* ReactNativeBiometrics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -203,34 +211,43 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = ReactNativeBiometrics;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReactNativeBiometrics-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = ReactNativeBiometrics;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "ReactNativeBiometrics-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
* Add support for Curve25519 via Swift wrapper class
* Move to use LAContext in place of various deprecated keychain attributes
* Store private key as generic password
* Move to use `biometryCurrentSet` vs `biometryAny`